### PR TITLE
EffectiveDate and IssuedDate and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # fhirBundleGenerator
 - This is a Standalone set of APIs for generating Fhir transaction bundle (STU3) from other fhir bundle or collection of fhir resources
    - /getBundle - a GET Api
-        -   query parameters - patientId and patientName
+        -   query parameters - patientId, familyName and numReps
         -   patientId becomes part of the Patient resource Identifier and will be used to check for duplicate Patient resources
-        -   patientName is put in as the Patient's Family_Name. 
+        -   familyName is put in as the Patient's Family_Name
+        -   numReps determines the total number of duplicate Observations to be created per Loinc Code
         -   The given name is set to "Test" by default in the code
    - /bundleConverter/convert 
         -   This is a POST API

--- a/src/main/java/org/nmdp/controller/GetBundleController.java
+++ b/src/main/java/org/nmdp/controller/GetBundleController.java
@@ -40,12 +40,12 @@ public class GetBundleController implements GetBundleApi {
     @RequestMapping(value= "",
             produces = { "application/json" },
             method = RequestMethod.GET)
-    public ResponseEntity<String> getBundle(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "patientId", required = true) String patientId, @NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "patientName", required = true) String patientName) {
+    public ResponseEntity<String> getBundle(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "patientId", required = true) Object patientId,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "familyName", required = true) Object familyName,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "numReps", required = true) Object numReps) {
         try {
-
             GenerateLoincBundle aGLB = new GenerateLoincBundle();
-            aGLB.setMyPatientId(patientId);
-            aGLB.setMyPatientName(patientName);
+            aGLB.setMyPatientId((String)patientId);
+            aGLB.setMyPatientName((String)familyName);
+            aGLB.setMyNumReps(Integer.parseInt((String)numReps));
             aGLB.createFHIR();
             return new ResponseEntity<>(aGLB.getMyFhirOutput(), HttpStatus.OK);
 

--- a/src/main/java/org/nmdp/converter/GenerateLoincBundle.java
+++ b/src/main/java/org/nmdp/converter/GenerateLoincBundle.java
@@ -23,10 +23,7 @@ import org.nmdp.utils.ConfigToMap;
 import org.nmdp.utils.FhirGuid;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * Loinc Based Bundle Generation Class
@@ -38,6 +35,12 @@ public class GenerateLoincBundle
     private String myPatientId;
 
     private String myPatientName;
+
+    private int myNumReps;
+
+    public void setMyNumReps(int myNumReps) {
+        this.myNumReps = myNumReps;
+    }
 
     public void setMyPatientName(String myPatientName) {
         this.myPatientName = myPatientName;
@@ -70,8 +73,11 @@ public class GenerateLoincBundle
         aDomainResources.add(aP);
         //NOTE: Following line of code can be repeated as many times
         // as needed to generate duplicate copies of each observation
-        myLoincDescMap.keySet().stream().filter(Objects::nonNull)
-                .forEach(aKey -> aDomainResources.add(getResource(aKey, myLoincDescMap.get(aKey), aP)));
+        for (int aCount=0; aCount < myNumReps; aCount++ )
+        {
+            myLoincDescMap.keySet().stream().filter(Objects::nonNull)
+                    .forEach(aKey -> aDomainResources.add(getResource(aKey, myLoincDescMap.get(aKey), aP)));
+        }
         aBG.generateFhirBundle(aDomainResources);
         FhirContext ctx = FhirContext.forDstu3();
         setMyFhirOutput(ctx.newJsonParser().setPrettyPrint(true).encodeResourceToString(aBG.getMyBundleResource().getMyFhirBundle()));
@@ -112,6 +118,11 @@ public class GenerateLoincBundle
         Reference aSubjRef = new Reference();
         aSubjRef.setReference(thePat.getIdElement().getValue());
         aObs.setSubject(aSubjRef);
+
+        // Adding Effective Date and Issued Date to Observation
+        DateTimeType aTypeDate = new DateTimeType(new Date());
+        aObs.setEffective(aTypeDate);
+        aObs.setIssued(aTypeDate.getValue());
 
         return aObs;
     }

--- a/src/main/resources/swagger/swagger-spec.yaml
+++ b/src/main/resources/swagger/swagger-spec.yaml
@@ -44,7 +44,12 @@ paths:
           schema:
             type: string
         - in: query
-          name: patientName
+          name: familyName
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: numReps
           required: true
           schema:
             type: string


### PR DESCRIPTION
Added support to include issuedDate and effectiveDate for Observation resources.

Also added an extra query parameter to the /getBundle API to specify the number of duplicate Observations to be created per LOINC code in the data-definition file.

Signed-off-by: jiyer2 <jiyer2@nmdp.org>